### PR TITLE
Number of nodes specific to depth

### DIFF
--- a/examples/classification.py
+++ b/examples/classification.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from math import isinf
+import time
 from typing import Annotated
 
 import numpy as np
@@ -14,6 +15,10 @@ from geneticengine.core.grammar import extract_grammar
 from geneticengine.core.grammar import Grammar
 from geneticengine.core.problems import Problem
 from geneticengine.core.problems import SingleObjectiveProblem
+from geneticengine.core.random.sources import RandomSource
+from geneticengine.core.representations.tree.initializations import grow_method
+from geneticengine.core.representations.tree.treebased import random_individual
+from geneticengine.core.representations.tree.utils import get_nodes_depth_specific
 from geneticengine.grammars.basic_math import SafeDiv
 from geneticengine.grammars.sgp import Mul
 from geneticengine.grammars.sgp import Number
@@ -126,6 +131,15 @@ class ClassificationBenchmark:
 
     def main(self, **args):
         g = self.get_grammar()
+
+        def find_depth_specific_nodes(r, g, depth):
+            ind = random_individual(r,g,depth,method=grow_method)
+            return get_nodes_depth_specific(ind,g)
+        r = RandomSource(123)
+        start = time.time()
+        print(g.get_branching_average_proxy(r, find_depth_specific_nodes, 100, 17))
+        print(time.time() - start)
+
         prob = self.get_problem()
         alg = SimpleGP(
             g,

--- a/geneticengine/core/grammar.py
+++ b/geneticengine/core/grammar.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import random
 import warnings
 from abc import ABC
 from abc import ABCMeta
@@ -326,6 +327,17 @@ class Grammar:
         self.preprocess()
         return self
 
+    def get_branching_average_proxy(self, r, get_nodes_depth_specific, n_individuals:int = 100, max_depth:int = 17):
+        branching_factors = dict()
+        for i in range(max_depth):
+            branching_factors[str(i)] = 0
+        for idx in range(n_individuals):
+            n_d_specs = get_nodes_depth_specific(r, self, max_depth)
+            for key in n_d_specs.keys():
+                branching_factors[key] = (branching_factors[key] * idx + n_d_specs[key]) / (idx + 1)
+        
+        return branching_factors
+
     def get_grammar_properties_summary(self) -> GrammarSummary:
         """Returns a summary of grammar properties:
 
@@ -337,7 +349,7 @@ class Grammar:
             - Per non-terminal, all the alternative productions
             - The total number of productions
             - The average number of productions per non-terminal
-            - The avergae non-terminals per production for each non-terminal
+            - The average non-terminals per production for each non-terminal
         """
         depth_min = self.get_min_tree_depth()
         depth_max = self.get_max_node_depth()

--- a/geneticengine/core/representations/tree/utils.py
+++ b/geneticengine/core/representations/tree/utils.py
@@ -32,7 +32,7 @@ def relabel_nodes(
     g: Grammar,
     is_list: bool = False,
 ) -> tuple[int, int, dict[type, list[Any]], int]:
-    """Recomputes all the nodes, depth and distance_to_term in the tree.\n
+    """Recomputes node specifics in the tree.\n
     Returns the number of nodes, distance to terminal (depth), typed this way,
     and the weighted number of nodes (counting depth points instead of
     nodes)."""
@@ -105,3 +105,30 @@ def relabel_nodes_of_trees(i: TreeNode, g: Grammar) -> TreeNode:
 
     relabel_nodes(i, g)
     return i
+
+def get_nodes_depth_specific(i: TreeNode, g: Grammar):
+    depth = i.gengy_distance_to_term
+    if not i.gengy_labeled:
+        relabel_nodes_of_trees(i)
+    
+    nodes_depth_specific = dict()
+    def add_count(node: TreeNode, n_d_spec_dict: dict):
+        if hasattr(node, "gengy_distance_to_term"):
+            try: 
+                n_d_spec_dict[str(depth - node.gengy_distance_to_term)] += 1
+            except:
+                n_d_spec_dict[str(depth - node.gengy_distance_to_term)] = 1
+
+        if not (is_terminal(type(node), g.non_terminals) and (not isinstance(node, list))):
+            if isinstance(node, list):
+                children = [(type(obj), obj) for obj in node]
+            else:
+                if not hasattr(node, "gengy_init_values"):
+                    breakpoint()
+                children = [(typ[1], node.gengy_init_values[idx]) for idx, typ in enumerate(get_arguments(node))]
+            for t, c in children:
+                n_d_spec_dict = add_count(c, n_d_spec_dict)
+        return n_d_spec_dict
+    
+    add_count(i, nodes_depth_specific)
+    return nodes_depth_specific

--- a/geneticengine/core/representations/tree/utils.py
+++ b/geneticengine/core/representations/tree/utils.py
@@ -109,10 +109,10 @@ def relabel_nodes_of_trees(i: TreeNode, g: Grammar) -> TreeNode:
 def get_nodes_depth_specific(i: TreeNode, g: Grammar):
     depth = i.gengy_distance_to_term
     if not i.gengy_labeled:
-        relabel_nodes_of_trees(i)
+        relabel_nodes_of_trees(i, g)
     
-    nodes_depth_specific = dict()
-    def add_count(node: TreeNode, n_d_spec_dict: dict):
+    nodes_depth_specific: dict[str, float] = dict()
+    def add_count(node: TreeNode, n_d_spec_dict: dict[str, float]):
         if hasattr(node, "gengy_distance_to_term"):
             try: 
                 n_d_spec_dict[str(depth - node.gengy_distance_to_term)] += 1

--- a/tests/relabel_test.py
+++ b/tests/relabel_test.py
@@ -1,10 +1,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Annotated
 
 from geneticengine.core.decorators import abstract
 from geneticengine.core.grammar import extract_grammar
-from geneticengine.core.representations.tree.utils import relabel_nodes_of_trees
+from geneticengine.core.random.sources import RandomSource
+from geneticengine.core.representations.tree.initializations import grow_method
+from geneticengine.core.representations.tree.treebased import random_individual
+from geneticengine.core.representations.tree.utils import get_nodes_depth_specific, relabel_nodes_of_trees
+from geneticengine.metahandlers.lists import ListSizeBetween
 
 
 @abstract
@@ -20,6 +25,10 @@ class Middle(Root):
 class Concrete(Root):
     pass
 
+@dataclass
+class MiddleList(Root):
+    z: Annotated[list[Root], ListSizeBetween(2, 3)]
+
 
 class TestRelabel:
     def test_relabel_simple(self):
@@ -27,3 +36,19 @@ class TestRelabel:
         g = extract_grammar([Concrete], Root)
         relabel_nodes_of_trees(c, g)
         assert c.gengy_distance_to_term == 0
+
+class TestNodesDepthSpecific:
+    def test_nodes_depth_specific_simple(self):
+        r = RandomSource(123)
+        g1 = extract_grammar([Concrete, Middle, MiddleList], Middle)
+        g2 = extract_grammar([Concrete, Middle, MiddleList], MiddleList)
+        g3 = extract_grammar([Concrete, Middle], Middle)
+        def find_depth_specific_nodes(r, g, depth):
+            ind = random_individual(r,g,depth,method=grow_method)
+            return get_nodes_depth_specific(ind,g)
+        branching_average1 = g1.get_branching_average_proxy(r, find_depth_specific_nodes, 100, 17)
+        assert branching_average1['0'] == 1
+        branching_average2 = g2.get_branching_average_proxy(r, find_depth_specific_nodes, 100, 17)
+        assert branching_average2['0'] >= 2 and branching_average2['0'] <= 3
+        branching_average3 = g3.get_branching_average_proxy(r, find_depth_specific_nodes, 100, 17)
+        assert branching_average3['0'] == branching_average3['1']


### PR DESCRIPTION
Hi Alcides,

I added the number of nodes specific to depth as a proxy for the branching average. It now returns a dictionary with values for each depth. How would you like to see this inside of the columns? I suppose we want a single value, correct?