### PR TITLE
Metahandler Union added

### DIFF
--- a/geneticengine/grammar/grammar.py
+++ b/geneticengine/grammar/grammar.py
@@ -245,12 +245,12 @@ class Grammar:
                 if is_union(ty):
                     yield from explode_generics(get_generic_parameters(ty))
                 elif is_generic_list(ty) or is_annotated(ty):
-                    yield get_generic_parameters(ty)
+                    yield from explode_generics([get_generic_parameter(ty)])
                 else:
                     yield ty
 
         def process_reachability(src: type, dsts: list[type]):
-            src = strip_annotations(src) #TODO remove strip annotations???
+            src = strip_annotations(src)  # TODO remove strip annotations???
             ch = False
             src_reach = reachability[src]
             for prod in explode_generics(dsts):

--- a/geneticengine/grammar/utils.py
+++ b/geneticengine/grammar/utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import inspect
 from abc import ABC
-from typing import Any
+from typing import Any, get_origin, Union
 from typing import Callable
 from typing import get_type_hints
 from typing import Protocol
@@ -43,6 +43,11 @@ def is_generic_list(ty: type[Any]):
 def is_generic(ty: type[Any]):
     """Returns whether a type is x[T] for any T."""
     return hasattr(ty, "__origin__")
+
+
+def is_union(ty: type[Any]):
+    """Returns whether a type is List[T] for any T."""
+    return get_origin(ty) is Union
 
 
 def get_generic_parameters(ty: type[Any]) -> list[type]:
@@ -93,6 +98,8 @@ def get_arguments(n) -> list[tuple[str, type]]:
 
 def is_abstract(t: type) -> bool:
     """Returns whether a class is a Protocol or AbstractBaseClass."""
+    if is_union(t):
+        return False
     return t.mro()[1] in [ABC, Protocol] or get_gengy(t).get("abstract", False)
 
 

--- a/geneticengine/representations/tree/initializations.py
+++ b/geneticengine/representations/tree/initializations.py
@@ -277,8 +277,7 @@ def expand_node(
         receiver(valb)
         return
     elif is_union(starting_symbol):
-        args = get_generic_parameters(starting_symbol)
-        option = r.choice(args)
+        option = r.choice(get_generic_parameters(starting_symbol))
         new_symbol(option, receiver, depth, id, ctx)
         return
     elif is_generic_list(starting_symbol):
@@ -344,7 +343,7 @@ def expand_node(
                 rule = r.choice(valid_productions, str(starting_symbol))
             new_symbol(rule, receiver, depth - extra_depth, id, ctx)
         else:  # Normal production
-            args = get_arguments(starting_symbol)
+            args: list[tuple[str, type]] = get_arguments(starting_symbol)
             ctx = ctx.copy()
             li: list[Any] = []
             for argn, _ in args:

--- a/geneticengine/representations/tree/initializations.py
+++ b/geneticengine/representations/tree/initializations.py
@@ -8,7 +8,7 @@ from geneticengine.grammar.grammar import Grammar
 from geneticengine.random.sources import RandomSource
 from geneticengine.solutions.tree import GengyList
 from geneticengine.representations.tree.utils import relabel_nodes_of_trees
-from geneticengine.grammar.utils import build_finalizers
+from geneticengine.grammar.utils import build_finalizers, is_union, get_generic_parameters
 from geneticengine.grammar.utils import get_arguments
 from geneticengine.grammar.utils import get_generic_parameter
 from geneticengine.grammar.utils import is_abstract
@@ -275,6 +275,11 @@ def expand_node(
     elif starting_symbol is bool:
         valb = r.random_bool(str(starting_symbol))
         receiver(valb)
+        return
+    elif is_union(starting_symbol):
+        args = get_generic_parameters(starting_symbol)
+        option = r.choice(args)
+        new_symbol(option, receiver, depth, id, ctx)
         return
     elif is_generic_list(starting_symbol):
         ctx = ctx.copy()

--- a/tests/core/metahandlers_test.py
+++ b/tests/core/metahandlers_test.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from abc import ABC
 from dataclasses import dataclass
-from typing import Annotated
+from typing import Annotated, Union
 
 import numpy as np
 
@@ -24,6 +24,11 @@ class Root(ABC):
 @dataclass
 class IntRangeM(Root):
     x: Annotated[int, IntRange[9, 10]]
+
+
+@dataclass
+class UnionIntRangeM(Root):
+    x: Union[Annotated[int, IntRange[0, 10]], Annotated[int, IntRange[20, 30]]]
 
 
 @dataclass
@@ -158,3 +163,13 @@ class TestMetaHandler:
         assert isinstance(n, IntervalRangeM)
         assert 5 < n.x[1] - n.x[0] < 10 and n.x[1] < 100
         assert isinstance(n, Root)
+
+    def test_union_int(self):
+        r = NativeRandomSource(seed=1)
+        g = extract_grammar([UnionIntRangeM], Root)
+        for _ in range(100):
+            n = random_node(r, g, 3, Root)
+            assert isinstance(n, UnionIntRangeM)
+            assert (0 <= n.x <= 10) or (20 <= n.x <= 30)
+            assert isinstance(n, Root)
+


### PR DESCRIPTION
added the metahandler Union to support for example:

var:  Union[Annotated[int, IntRange(0,10)], Annotated[int, IntRange(20, 30)]]

so the variable can hold integers within the range of 0 to 10 or within the range of 20 to 30.

