### PR TITLE
Add regression test: RampedHalfAndHalf initializer does not respect max_depth (#259)

### DIFF
--- a/tests/representations/tree_based/initializer_test.py
+++ b/tests/representations/tree_based/initializer_test.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Annotated
 
+import pytest
+
 from geneticengine.problems import SingleObjectiveProblem
 
 
@@ -11,10 +13,15 @@ from geneticengine.grammar.grammar import extract_grammar
 from geneticengine.random.sources import NativeRandomSource
 from geneticengine.representations.tree.initializations import (
     FullDecider,
+    MaxDepthDecider,
     PositionIndependentGrowDecider,
     ProgressivelyTerminalDecider,
 )
-from geneticengine.representations.tree.operators import FullInitializer, GrowInitializer
+from geneticengine.representations.tree.operators import (
+    FullInitializer,
+    GrowInitializer,
+    RampedHalfAndHalfInitializer,
+)
 from geneticengine.representations.tree.treebased import TreeBasedRepresentation
 from geneticengine.grammar.metahandlers.floats import FloatRange
 from geneticengine.grammar.metahandlers.ints import IntervalRange
@@ -53,6 +60,22 @@ class C(A):
     two: A
 
 
+@abstract
+class Expr:
+    pass
+
+
+@dataclass
+class Leaf(Expr):
+    pass
+
+
+@dataclass
+class Branch(Expr):
+    left: Expr
+    right: Expr
+
+
 class TestInitializers:
     def test_full(self):
         target_size = 10
@@ -83,6 +106,31 @@ class TestInitializers:
         assert len(population) == target_size
         for ind in population:
             assert ind.get_phenotype().gengy_distance_to_term <= target_depth
+
+    @pytest.mark.xfail(strict=True, reason="https://github.com/alcides/GeneticEngine/issues/259")
+    def test_ramped_half_and_half_respects_max_depth(self):
+        """Regression test for https://github.com/alcides/GeneticEngine/issues/259.
+
+        RampedHalfAndHalfInitializer receives a max_depth, but ignores it:
+        initialize() calls representation.create_genotype() without a
+        depth-bounded decider, so individuals are generated with the
+        representation's default decider instead.
+        """
+        target_size = 20
+        target_depth = 3
+
+        g = extract_grammar([Leaf, Branch], Expr)
+        f = RampedHalfAndHalfInitializer(max_depth=target_depth)
+        p = SingleObjectiveProblem(lambda x: 3)
+        rs = NativeRandomSource(5)
+        repr = TreeBasedRepresentation(grammar=g, decider=MaxDepthDecider(rs, g, max_depth=10))
+
+        population = list(f.initialize(p, repr, rs, target_size))
+        assert len(population) == target_size
+        depths = [ind.get_phenotype().gengy_distance_to_term for ind in population]
+        assert all(
+            depth <= target_depth for depth in depths
+        ), f"RampedHalfAndHalfInitializer(max_depth={target_depth}) produced trees with depths {depths}"
 
     def test_progressive(self):
         target_size = 10


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a strict-`xfail` regression test documenting [issue #259](https://github.com/alcides/GeneticEngine/issues/259): `RampedHalfAndHalfInitializer` accepts a `max_depth` argument but does not respect it.

No production code is changed in this PR — the test is living evidence of the bug, and will start failing (via `xfail(strict=True)`) the moment the bug is fixed, prompting removal of the marker.

## Root cause (for reference)

`RampedHalfAndHalfInitializer.__init__` stores `max_depth`, but `initialize()` calls `representation.create_genotype(random)` without passing a depth-bounded decider, so the representation's default decider is used and `max_depth` is silently ignored (compare with `FullInitializer`, which passes its own depth-bounded `FullDecider`). It also does not do any ramping or grow/full alternation, contrary to its docstring.

## How to run

```bash
uv run pytest tests/representations/tree_based/initializer_test.py::TestInitializers::test_ramped_half_and_half_respects_max_depth -v
```

Currently reports `XFAIL`. To see the underlying failure, remove the `xfail` marker and run again.

## Evidence (assertion output without the xfail marker)

The test builds a tiny recursive grammar (`Expr` → `Leaf` | `Branch(Expr, Expr)`), requests a population of 20 from `RampedHalfAndHalfInitializer(max_depth=3)` with a fixed seed (`NativeRandomSource(5)`), and asserts every individual's depth is ≤ 3:

```
E       AssertionError: RampedHalfAndHalfInitializer(max_depth=3) produced trees with depths [9, 3, 3, 3, 4, 1, 1, 1, 1, 1, 1, 1, 5, 2, 1, 1, 1, 1, 6, 5]
E       assert False
```

Expected: all depths ≤ 3. Actual: 5 of 20 individuals exceed the limit (depths 4, 5, 5, 6, and 9).

## Checks

- `uv run pytest`: 520 passed, 8 skipped, 1 xfailed (the new test)
- `ruff check . --fix`: all checks passed

Closes nothing; references https://github.com/alcides/GeneticEngine/issues/259.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d3f50a29-112a-41c4-9a94-9dfe7ee692b1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d3f50a29-112a-41c4-9a94-9dfe7ee692b1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

